### PR TITLE
Allow overwriting input with output

### DIFF
--- a/Services/CleanableFactory.cs
+++ b/Services/CleanableFactory.cs
@@ -65,18 +65,15 @@ public class CleanableFactory
     /// <param name="outputFolderPath">The output location for each new object.</param>
     /// <returns>An array of <see cref="Cleanable"/>.</returns>
     /// <exception cref="DirectoryNotFoundException">When the <paramref name="inputFolderPath"/> is not a directory.</exception>
-    public Cleanable[] CreateFromFolder(string inputFolderPath, string? outputFolderPath)
+    public Cleanable[] CreateFromFolder(string inputFolderPath, string outputFolderPath)
     {
         if (!Directory.Exists(inputFolderPath)) throw new DirectoryNotFoundException("Input folder doesn't exist.");
 
         string[] inputFolderContents = Directory.GetFileSystemEntries(inputFolderPath);
-        bool useDefaultOutputFilenameSuffix = outputFolderPath is null;
 
         var cleanables = inputFolderContents.Select(inputFilePath =>
         {
-            string outputFilePath = useDefaultOutputFilenameSuffix
-                ? null
-                : Path.Combine(outputFolderPath, Path.GetFileName(inputFilePath));
+            string outputFilePath = Path.Combine(outputFolderPath, Path.GetFileName(inputFilePath));
             Cleanable cleanable = Create(inputFilePath, outputFilePath);
             return cleanable;
         }).ToArray();

--- a/Services/Cleaner.cs
+++ b/Services/Cleaner.cs
@@ -13,7 +13,7 @@ namespace FixedLengthFile_Cleaner.Services;
 public class Cleaner
 {
     private StatusMessenger.StatusMessenger _statusMessenger = StatusMessenger.StatusMessenger.GetInstance();
-    
+
     /// <summary>
     /// Creates a <see cref="Task"/> that encapsulates the business logic for processing a <see cref="Cleanable"/> based 
     /// on its <see cref="Cleanable.Type"/>.
@@ -78,12 +78,31 @@ public class Cleaner
         {
             Log.Logger.Information($"Cleaning file {textFile.InputPath}...");
 
+            // Creating a temporary file handle in case we can't write to the textfile's output path yet
+            var tdm = App.FetchService<TemporaryDataManager>();
+            using ITemporaryFile tempFile = tdm.CreateTemporaryFile();
+
+            // If the new file is overwriting the old file we must take additional steps
+            bool overwritingOriginalFile = textFile.InputPath == textFile.OutputPath;
+
+            string writeToPath;
+            if (overwritingOriginalFile)
+            {
+                // Can't write a file over a file being read, so we'll write it elsewhere and move it once we're done
+                writeToPath = tempFile.Path;
+            }
+            else
+            {
+                writeToPath = textFile.OutputPath;
+            }
+
             // Todo: Update this method to use the configuration to set the find/replace characters
             // Todo: Refactor to scan over a string rather than a single character
             try
             {
+                // Todo: Encapsulate this process to a separate service, let the "number of quotes" be an out parameter
                 using (StreamReader input = new StreamReader(textFile.InputPath))
-                using (StreamWriter output = new StreamWriter(textFile.OutputPath))
+                using (StreamWriter output = new StreamWriter(writeToPath))
                 {
                     int character;
                     while ((character = input.Read()) != -1) // Read character by character
@@ -97,6 +116,12 @@ public class Cleaner
 
                         output.Write((char)character);
                     }
+                }
+
+                if (overwritingOriginalFile)
+                {
+                    // Move the output file from the temporary location to its final location, overwriting the input
+                    File.Move(writeToPath, textFile.OutputPath, true);
                 }
 
                 Log.Logger.Information(

--- a/Services/Cleaner.cs
+++ b/Services/Cleaner.cs
@@ -114,59 +114,51 @@ public class Cleaner
         return Task.Run(async () =>
         {
             var tdm = App.FetchService<TemporaryDataManager>();
-            string originalFilesFolder = Path.Combine(tdm.PathToTemporaryDirectory(), Path.GetRandomFileName());
-            string cleanedFilesFolder = originalFilesFolder + "_cleaned";
 
-            Log.Logger.Information($"Creating temporary folder at: {cleanedFilesFolder}");
-
-            Directory.CreateDirectory(cleanedFilesFolder);
-
-            _statusMessenger.SetStatus("Extracting files...");
-            Log.Logger.Information($"Unzipping file to {originalFilesFolder}");
-
-            try
+            using (ITemporaryDirectory originalFilesFolder = tdm.CreateTemporaryDirectory())
+            using (ITemporaryDirectory cleanedFilesFolder = tdm.CreateTemporaryDirectory())
             {
-                ZipFile.ExtractToDirectory(zipFile.InputPath, originalFilesFolder);
-                Log.Logger.Information($"Successfully unpacked {zipFile.InputPath}");
-            }
-            catch (Exception ex)
-            {
-                Log.Logger.Error(ex, $"Error while unpacking {zipFile.InputPath}");
-            }
+                Log.Logger.Information($"Creating temporary folder at: {cleanedFilesFolder}");
+                cleanedFilesFolder.EnsureExists();
 
-            var cf = App.FetchService<CleanableFactory>();
+                _statusMessenger.SetStatus("Extracting files...");
+                Log.Logger.Information($"Unzipping file to {originalFilesFolder.Path}");
 
-            Cleanable folder = cf.Create(originalFilesFolder, cleanedFilesFolder);
+                try
+                {
+                    ZipFile.ExtractToDirectory(zipFile.InputPath, originalFilesFolder.Path);
+                    Log.Logger.Information($"Successfully unpacked {zipFile.InputPath}");
+                }
+                catch (Exception ex)
+                {
+                    Log.Logger.Error(ex, $"Error while unpacking {zipFile.InputPath}");
+                }
 
-            await Clean(folder);
-            zipFile.NumberOfQuotes += folder.NumberOfQuotes;
+                var cf = App.FetchService<CleanableFactory>();
 
-            if (File.Exists(zipFile.OutputPath)) File.Delete(zipFile.OutputPath);
+                Cleanable folder = cf.Create(originalFilesFolder.Path, cleanedFilesFolder.Path);
 
-            _statusMessenger.SetStatus("Zipping files...");
-            Log.Logger.Information($"Zipping files...");
+                await Clean(folder);
+                zipFile.NumberOfQuotes += folder.NumberOfQuotes;
 
-            try
-            {
-                ZipFile.CreateFromDirectory(cleanedFilesFolder, zipFile.OutputPath);
-                Log.Logger.Information($"Successfully zipped {originalFilesFolder} to {zipFile.OutputPath}.");
-            }
-            catch (Exception ex)
-            {
-                Log.Logger.Error(ex, $"Error while zipping {cleanedFilesFolder}:");
-            }
+                if (File.Exists(zipFile.OutputPath)) File.Delete(zipFile.OutputPath);
 
-            _statusMessenger.SetStatus("Deleting temporary files...");
+                _statusMessenger.SetStatus("Zipping files...");
+                Log.Logger.Information($"Zipping files...");
 
-            try
-            {
+                try
+                {
+                    ZipFile.CreateFromDirectory(cleanedFilesFolder.Path, zipFile.OutputPath);
+                    Log.Logger.Information($"Successfully zipped {originalFilesFolder.Path} to {zipFile.OutputPath}.");
+                }
+                catch (Exception ex)
+                {
+                    Log.Logger.Error(ex, $"Error while zipping {cleanedFilesFolder.Path}:");
+                }
+
+                _statusMessenger.SetStatus("Deleting temporary files...");
+
                 Log.Logger.Information($"Deleting temporary directories...");
-                Directory.Delete(originalFilesFolder, true);
-                Directory.Delete(cleanedFilesFolder, true);
-            }
-            catch (Exception ex)
-            {
-                Log.Logger.Error(ex, $"Error occured while deleting temporary directories:");
             }
         });
     }

--- a/Services/Cleaner.cs
+++ b/Services/Cleaner.cs
@@ -50,16 +50,8 @@ public class Cleaner
 
             Log.Logger.Information("Creating collection from folder contents...");
 
-            Cleanable[] cleanables;
-            if (folder.InputPath == folder.OutputPath)
-            {
-                cleanables = cf.CreateFromFolder(folder.InputPath, null);
-            }
-            else
-            {
-                Directory.CreateDirectory(folder.OutputPath);
-                cleanables = cf.CreateFromFolder(folder.InputPath, folder.OutputPath);
-            }
+            Cleanable[] cleanables = cf.CreateFromFolder(folder.InputPath, folder.OutputPath);
+            Directory.CreateDirectory(folder.OutputPath);
 
             int i = 1;
             foreach (var cleanable in cleanables)

--- a/Services/TemporaryDataManager.cs
+++ b/Services/TemporaryDataManager.cs
@@ -14,12 +14,17 @@ public interface ITemporaryDirectory : IDisposable
     void EnsureExists();
 }
 
+public interface ITemporaryFile : IDisposable
+{
+    string Path { get; }
+}
+
 /// <summary>
 /// Service for managing temporary resources allocation throughout the application's lifetime.
 /// </summary>
 public class TemporaryDataManager : IDisposable
 {
-    public string PathToTemporaryDirectory() => Path.Combine(Path.GetTempPath(), Program.ApplicationName);
+    private string PathToTemporaryDirectory() => Path.Combine(Path.GetTempPath(), Program.ApplicationName);
     
     public TemporaryDataManager()
     {
@@ -36,6 +41,9 @@ public class TemporaryDataManager : IDisposable
 
     public ITemporaryDirectory CreateTemporaryDirectory() =>
         new TemporaryDirectory(Path.Combine(PathToTemporaryDirectory(), Path.GetRandomFileName()));
+
+    public ITemporaryFile CreateTemporaryFile() =>
+        new TemporaryFile(Path.Combine(PathToTemporaryDirectory(), Path.GetRandomFileName()));
     
     public void Dispose()
     {
@@ -70,6 +78,21 @@ public class TemporaryDataManager : IDisposable
         public void Dispose()
         {
             Directory.Delete(Path, true);
+        }
+    }
+
+    private class TemporaryFile : ITemporaryFile
+    {
+        public string Path { get; }
+
+        public TemporaryFile(string path)
+        {
+            Path = path;
+        }
+        
+        public void Dispose()
+        {
+            File.Delete(Path);
         }
     }
 }

--- a/Services/TemporaryDataManager.cs
+++ b/Services/TemporaryDataManager.cs
@@ -8,11 +8,19 @@ using Serilog;
 
 namespace FixedLengthFile_Cleaner.Services;
 
+public interface ITemporaryDirectory : IDisposable
+{
+    string Path { get; }
+    void EnsureExists();
+}
+
 /// <summary>
 /// Service for managing temporary resources allocation throughout the application's lifetime.
 /// </summary>
 public class TemporaryDataManager : IDisposable
 {
+    public string PathToTemporaryDirectory() => Path.Combine(Path.GetTempPath(), Program.ApplicationName);
+    
     public TemporaryDataManager()
     {
         Log.Logger.Information("Creating temporary data manager...");
@@ -26,6 +34,9 @@ public class TemporaryDataManager : IDisposable
         Log.Logger.Information($"Created temporary data directory {PathToTemporaryDirectory()}");
     }
 
+    public ITemporaryDirectory CreateTemporaryDirectory() =>
+        new TemporaryDirectory(Path.Combine(PathToTemporaryDirectory(), Path.GetRandomFileName()));
+    
     public void Dispose()
     {
         Log.Logger.Information("Deleting temporary data directory");
@@ -45,5 +56,21 @@ public class TemporaryDataManager : IDisposable
         }
     }
 
-    public string PathToTemporaryDirectory() => Path.Combine(Path.GetTempPath(), Program.ApplicationName);
+    private class TemporaryDirectory : ITemporaryDirectory
+    {
+        public string Path { get; }
+        
+        public void EnsureExists() => Directory.CreateDirectory(Path);
+
+        public TemporaryDirectory(string path)
+        {
+            Path = path;
+        }
+        
+        public void Dispose()
+        {
+            Directory.Delete(Path, true);
+        }
+    }
 }
+


### PR DESCRIPTION
## What does this do?
Adds new classes and refactors existing methods to support overwriting the selected input file/folder. 

## What changed?
- All temp folder locations are now randomly. Access to these locations is provided by the `TemporaryDataManager` via `ITemporaryDirectory` and `ITemporaryFile`, which are defined as disposable path handles that delete themselves once they're done being used.
- Setting the output of a text file to its input will now overwrite the text file after the process has completed. It does this by first writing the file to the temporary directory, then moving it to overwrite the original.
- Setting the output target of a folder to its input will overwrite the contents of the folder. This process is the same as the bullet above.

Closes #3